### PR TITLE
Add 32bit support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuteye"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Brian Martin <brayniac@gmail.com>"]
 
 license = "MIT OR Apache-2.0"
@@ -16,3 +16,9 @@ readme = "README.md"
 keywords = [ "shuteye", "sleep", "nanosecond", "nanosleep" ]
 
 include = [ "src/**/*", "README.md", "LICENSE-*", "Cargo.toml" ]
+
+[dependencies]
+libc = "^0.2"
+
+[dev-dependencies]
+time = "^0.1"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use `shuteye`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-shuteye = "*"
+shuteye = "^0"
 ```
 
 Then, add this to your crate root:

--- a/tests/test_sleep.rs
+++ b/tests/test_sleep.rs
@@ -1,0 +1,37 @@
+extern crate shuteye;
+extern crate time;
+
+use std::time::Duration;
+
+use shuteye::sleep;
+use time::precise_time_ns;
+
+fn duration_from_ns(duration_ns: u64) -> Duration {
+    Duration::new(duration_ns / 1_000_000_000,
+                  (duration_ns % 1_000_000_000) as u32)
+}
+
+fn measure_sleep(sleep_duration: Duration) -> Duration {
+    let start = precise_time_ns();
+    let _remain = sleep(sleep_duration);
+    let end = precise_time_ns();
+
+    let remain = match _remain {
+        Some(remain) => remain,
+        None => Duration::new(0, 0),
+    };
+
+    duration_from_ns(end - start) + remain
+}
+
+#[test]
+fn sleep_1s() {
+    let duration = Duration::new(1, 0);
+    assert!(measure_sleep(duration) >= duration);
+}
+
+#[test]
+fn sleep_less_1s() {
+    let duration = Duration::new(0, 999_999_999);
+    assert!(measure_sleep(duration) >= duration);
+}


### PR DESCRIPTION
The `Timespec` struct uses `i32` on 32 bit systems.
To handle all possible edge cases I switched to `libc`.

Also basic sleep tests are added.