### PR TITLE
rustfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.bk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 keywords = [ "shuteye", "sleep", "nanosecond", "nanosleep" ]
 
-include = [ "src/**/*", "README.md", "LICENSE-*", "Cargo.toml" ]
+exclude = [ "scripts" ]
 
 [dependencies]
 libc = "^0.2"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+reorder_imports = true
+reorder_imported_names = true

--- a/tests/test_sleep.rs
+++ b/tests/test_sleep.rs
@@ -1,9 +1,9 @@
 extern crate shuteye;
 extern crate time;
 
-use std::time::Duration;
 
 use shuteye::sleep;
+use std::time::Duration;
 use time::precise_time_ns;
 
 fn duration_from_ns(duration_ns: u64) -> Duration {


### PR DESCRIPTION
Minor changes to formatting standard (re-ordering imports). Use 'exclude' instead of 'include' in Cargo.toml. 