### PR TITLE
use libc types, fixes 32bit build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,8 @@ pub fn sleep(duration: Duration) -> Option<Duration> {
 
 fn duration_to_timespec(duration: Duration) -> libc::timespec {
     libc::timespec {
-        tv_sec: duration.as_secs() as i64,
-        tv_nsec: duration.subsec_nanos() as i64,
+        tv_sec: duration.as_secs() as libc::time_t,
+        tv_nsec: duration.subsec_nanos() as libc::c_long,
     }
 }
 


### PR DESCRIPTION
I missed some typedefs in 054d89f6783eb5fb4b9019b859dc1fb4dae3bbd9 which results in compile errors:
```
   Compiling shuteye v0.3.1
error[E0308]: mismatched types
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/shuteye-0.3.1/src/lib.rs:75:17
   |
75 |         tv_sec: duration.as_secs() as i64,
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ expected i32, found i64

error[E0308]: mismatched types
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/shuteye-0.3.1/src/lib.rs:76:18
   |
76 |         tv_nsec: duration.subsec_nanos() as i64,
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected i32, found i64

error: aborting due to previous error(s)

error: Could not compile `shuteye`.

To learn more, run the command again with --verbose.
```

This commit should fix those.